### PR TITLE
Ret parameter in NEG_CHK should be of type int not void.

### DIFF
--- a/error.c
+++ b/error.c
@@ -26,7 +26,7 @@ void null_chk(void* ret, const char* func, const char* file, int line) {
     exit(EXIT_FAILURE);
 }
 
-void neg_chk(void* ret, const char* func, const char* file, int line) {
+void neg_chk(int ret, const char* func, const char* file, int line) {
     if (ret >= 0)
         return;
     fprintf(stderr,

--- a/error.h
+++ b/error.h
@@ -24,7 +24,7 @@
 
 #define MALLOC_CHK(ret) malloc_chk((void*)ret, __func__, __FILE__, __LINE__)
 #define NULL_CHK(ret) null_chk((void*)ret, __func__, __FILE__, __LINE__)
-#define NEG_CHK(ret) neg_chk((void*)ret, __func__, __FILE__, __LINE__)
+#define NEG_CHK(ret) neg_chk(ret, __func__, __FILE__, __LINE__)
 
 void malloc_chk(void* ret, const char* func, const char* file, int line);
 
@@ -32,6 +32,6 @@ void malloc_chk(void* ret, const char* func, const char* file, int line);
 void null_chk(void* ret, const char* func, const char* file, int line);
 
 // Die on error. Print the error and exit if the return value of the previous function is -1
-void neg_chk(void* ret, const char* func, const char* file, int line);
+void neg_chk(int ret, const char* func, const char* file, int line);
 
 #endif


### PR DESCRIPTION
Fixes bug in the NEG_CHECK macro and function.