### PR TITLE
added arm64 build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ jobs:
       packages:
         - zlib1g-dev
   include:
+    - name: "arm64 build"
+      arch: arm64
+      addons:
+        apt:
+          packages:
+            - zlib1g-dev
+      script: autoreconf && ./scripts/install-hdf5.sh 2> /dev/null &&./scripts/install-hts.sh && ./configure --enable-localhdf5 && make && make test
     - name: "Ubuntu 14 local hts"
       dist: trusty
       addons:


### PR DESCRIPTION
now Travis supports multiple CPU architectures. but still not for arm32. zlib1g-dev worked only when included inside the job.